### PR TITLE
Fix NullPointerException when setting mail port

### DIFF
--- a/src/main/java/com/qux/MATC.java
+++ b/src/main/java/com/qux/MATC.java
@@ -250,8 +250,8 @@ public class MATC extends AbstractVerticle {
 			MailConfig mailConfig = new MailConfig();
 			mailConfig.setHostname(config.getString("host"));
 			if (config.containsKey("port")) {
-				logger.info("createMail() > Set port to " + config.getInteger(Config.MAIL_PORT));
-				mailConfig.setPort(config.getInteger(Config.MAIL_PORT));
+				logger.info("createMail() > Set port to " + config.getInteger("port"));
+				mailConfig.setPort(config.getInteger("port"));
 			} else {
 				mailConfig.setPort(587);
 			}


### PR DESCRIPTION
This fixes the NullPointerException I got while testing the docker image.

```java
WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact performance.
May 04, 2023 8:43:06 PM io.vertx.core.Starter
SEVERE: Failed in deploying verticle
java.lang.NullPointerException: Cannot invoke "java.lang.Integer.intValue()" because the return value of "io.vertx.core.json.JsonObject.getInteger(String)" is null
	at com.qux.MATC.createMail(MATC.java:254)
	at com.qux.MATC.initMail(MATC.java:229)
	at com.qux.MATC.start(MATC.java:97)
	at io.vertx.core.AbstractVerticle.start(AbstractVerticle.java:108)
	at io.vertx.core.Verticle.start(Verticle.java:66)
	at io.vertx.core.impl.DeploymentManager.lambda$doDeploy$9(DeploymentManager.java:552)
	at io.vertx.core.impl.ContextImpl.executeTask(ContextImpl.java:366)
	at io.vertx.core.impl.EventLoopContext.lambda$executeAsync$0(EventLoopContext.java:38)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:164)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:469)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:503)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:833)
```