### PR TITLE
allow a different "from" which is not the "user"

### DIFF
--- a/src/main/java/com/qux/MATC.java
+++ b/src/main/java/com/qux/MATC.java
@@ -53,7 +53,6 @@ public class MATC extends AbstractVerticle {
 
 	private final String startedTime = LocalDateTime.now().toString();
 
-
 	public static String MAIL_USER = "";
 
 	private ITokenService tokenService;
@@ -104,7 +103,7 @@ public class MATC extends AbstractVerticle {
 		
 		
 		System.out.println("******************************************");
-		System.out.println("* Quant-UX-Server " + VERSION + " launched at " + config.getInteger("http.port") + "");
+		System.out.println("* Quant-UX-Server " + VERSION + " launched at " + config.getInteger("http.port"));
 		System.out.println("******************************************");
 	}
 
@@ -132,8 +131,12 @@ public class MATC extends AbstractVerticle {
 		}
 
 		if (config.containsKey(Config.MAIL_USER)) {
-			this.logger.info("start() > set mail user", MAIL_USER);
+			this.logger.info("start() > set mail user");
 			MAIL_USER = config.getString(Config.MAIL_USER);
+		}
+
+		if (config.containsKey(Config.MAIL_FROM)) {
+			MAIL_USER = config.getString(Config.MAIL_FROM);
 		}
 		return config;
 	}
@@ -176,7 +179,7 @@ public class MATC extends AbstractVerticle {
 		QUXTokenService tokenService = new QUXTokenService();
 		if (config.containsKey(Config.JWT_PASSWORD)){
 			String jwtSecret = config.getString(Config.JWT_PASSWORD);
-			if (jwtSecret.trim().length() > 0) {
+			if (!jwtSecret.trim().isEmpty()) {
 				tokenService.setSecret(jwtSecret);
 			} else {
 				logger.error("initQUXTokenService() > Password is empty");
@@ -210,11 +213,12 @@ public class MATC extends AbstractVerticle {
 
 		JsonObject mailConfig = Config.getMail(config);
 		if (mailConfig.containsKey("user")){
+			String mailFrom = mailConfig.containsKey("from") ? mailConfig.getString("from") : mailConfig.getString("user");
 			mail = createMail(mailConfig);
 			MailHandler.start(
 				vertx,
 				mail,
-				mailConfig.getString("user"),
+				mailFrom,
 				Config.getHttpHost(config)
 			);
 		}

--- a/src/main/java/com/qux/util/Config.java
+++ b/src/main/java/com/qux/util/Config.java
@@ -30,6 +30,8 @@ public class Config {
 
     public static final String ENV_MAIL_USER = "QUX_MAIL_USER";
 
+    public static final String ENV_MAIL_FROM = "QUX_MAIL_FROM";
+
     public static final String ENV_MAIL_PASSWORD = "QUX_MAIL_PASSWORD";
 
     public static final String ENV_MAIL_HOST = "QUX_MAIL_HOST";
@@ -79,6 +81,8 @@ public class Config {
     public static final String MONGO_CONNECTION_STRING = "mongo.connection_string";
 
     public static final String MAIL_USER = "mail.user";
+
+    public static final String MAIL_FROM = "mail.from";
 
     public static final String MAIL_PASSWORD = "mail.password";
 
@@ -144,6 +148,10 @@ public class Config {
 
             if (config.containsKey(MAIL_SSL)) {
                 mailConfig.put("ssl", config.getString(MAIL_SSL));
+            }
+
+            if (config.containsKey(MAIL_FROM)) {
+                mailConfig.put("from", config.getString(MAIL_FROM));
             }
         }
         return mailConfig;
@@ -302,6 +310,11 @@ public class Config {
         if (env.containsKey(ENV_MAIL_USER)) {
             logger.warn("mergeMail() > " + ENV_MAIL_USER);
             result.put(MAIL_USER, env.get(ENV_MAIL_USER));
+        }
+
+        if (env.containsKey(ENV_MAIL_FROM)) {
+            logger.warn("mergeMail() > " + ENV_MAIL_FROM);
+            result.put(MAIL_FROM, env.get(ENV_MAIL_FROM));
         }
         if (env.containsKey(ENV_MAIL_PASSWORD)) {
             logger.warn("mergeMail() > " + ENV_MAIL_PASSWORD);


### PR DESCRIPTION
Hey Klaus!

I was deploying quant-ux for our Research Institute and could not get it to work because our smtps server needs a seperate username and from. Since someone else might have this problem I thought i'd share my solution. 

Kind Regards,
Antonio